### PR TITLE
fix: specify kubectl version in gh-action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -71,6 +71,8 @@ runs:
 
     - name: Setup kubectl
       uses: azure/setup-kubectl@v3
+      with:
+        version: v1.28.0
 
     - name: Setup Golang
       uses: actions/setup-go@v4


### PR DESCRIPTION
Not having specific versions causes errors:
```
Error: Kubectl 'v1.28.3' for 'amd64' arch not found.
```